### PR TITLE
IGNORE - IAM and Processing fixes

### DIFF
--- a/iam/5-deployment.md
+++ b/iam/5-deployment.md
@@ -27,9 +27,11 @@ kubectl -n iam rollout status \
   deployment.apps/identity-api
 ```{{exec}}
 
-> DO NOT proceed until the above command completes, indicating that the IAM services are deployed.
+> DO NOT proceed until the above command completes, indicating that the IAM pods are now running.
 
 Once all pods are running and ready, you can check the Keycloak service discovery endpoint...
+
+> There may still be a short delay until the IAM services are ready and responding to requests.
 
 ```bash
 curl -k http://auth.eoepca.local/realms/eoepca/.well-known/openid-configuration | jq

--- a/iam/6-client-user.md
+++ b/iam/6-client-user.md
@@ -71,9 +71,9 @@ _Select the provided values to inject them into the terminal prompts_
   The secret that, together with the Client ID, provides the client credentials
 * Subdomain: `opa`{{exec}}<br>
   The main redirect URL for OIDC flows - within the `INGRESS_HOST`{{}} domain
-* Additional Subdomains: <Leave blank>``{{exec}}<br>
+* Additional Subdomains: <Leave blank><br>
   Additional redirect URLs for OIDC flows - within the `INGRESS_HOST`{{}} domain
-* Additional Hosts: <Leave blank>``{{exec}}<br>
+* Additional Hosts: <Leave blank><br>
   Additional redirect URLs for OIDC flows - external (outside the `INGRESS_HOST`{{}} domain)
 
 ### 3. Register the Identity API Client in Keycloak

--- a/iam/7-keycloak-ui.md
+++ b/iam/7-keycloak-ui.md
@@ -1,27 +1,6 @@
 ## Keycloak Admin UI
 
-### Port forward to the Keycloak service
-
-In order to access the Keycloak web UI, due to the limitations of this tutorial environment, it is necessary to port-forward directly to the Keycloak service.
-
-**Open another terminal tab to intitiate the port forwarding.**
-
-First we need the `socat`{{}} command:
-
-```bash
-apt update && apt install socat
-```{{exec}}
-
-Now we can initiate the port forwarding:
-
-```bash
-kubectl -n iam port-forward svc/iam-keycloak 8080:80 &
-socat TCP4-LISTEN:8888,fork TCP4:127.0.0.1:8080 &
-```{{exec}}
-
-**Switch back to the previous terminal tab, in the `deployment-guide/scripts/iam`{{}} directory.**
-
-### Open the Keycloak Web UI
+The Keycloak web UI has been made accessible through [this URL]({{TRAFFIC_HOST1_90}}).
 
 Login with the user `admin`{{}} and the password defined by the env var `KEYCLOAK_ADMIN_PASSWORD`{{}}.
 
@@ -29,7 +8,7 @@ Login with the user `admin`{{}} and the password defined by the env var `KEYCLOA
 cat ~/.eoepca/state | grep KEYCLOAK_ADMIN_PASSWORD
 ```{{exec}}
 
-[Click here]({{TRAFFIC_HOST1_8888}}) to open the Keycloak UI.
+[Click here]({{TRAFFIC_HOST1_90}}) to open the Keycloak UI.
 
 Select the `eoepca`{{}} realm.
 

--- a/iam/assets/apisixroute-nginx.yaml
+++ b/iam/assets/apisixroute-nginx.yaml
@@ -1,0 +1,45 @@
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: nginx
+spec:
+  http:
+    # Open access
+    - name: nginx-open
+      match:
+        hosts:
+          - nginx-open.{{ getenv "INGRESS_HOST" }}
+        paths:
+          - /*
+      backends:
+        - serviceName: nginx
+          servicePort: 80
+    # Protected access
+    - name: nginx
+      match:
+        hosts:
+          - nginx.{{ getenv "INGRESS_HOST" }}
+        paths:
+          - /*
+      backends:
+        - serviceName: nginx
+          servicePort: 80
+      plugins:
+        # Authenticate - expect JWT in `Authorization: Bearer` header
+        - name: openid-connect
+          enable: true
+          config:
+            discovery: "{{ getenv "OIDC_ISSUER_URL" }}/.well-known/openid-configuration"
+            realm: {{ getenv "OPA_CLIENT_SECRET" }}
+            client_id: {{ getenv "OPA_CLIENT_ID" }}
+            client_secret: {{ getenv "OPA_CLIENT_SECRET" }}
+            use_jwks: true
+            bearer_only: false
+            set_access_token_header: true
+            access_token_in_authorization_header: true
+        # Authorization - required for access to API
+        - name: opa
+          enable: true
+          config:
+            host: http://iam-opal-client.iam:8181
+            policy: example/tutorial/protected

--- a/processing/calrissian/configurezoo.md
+++ b/processing/calrissian/configurezoo.md
@@ -6,16 +6,16 @@ bash configure-oapip.sh
 
 The script will start with the general EOEPCA configuration.
 
+For the demo deployment we are not generating certificates, so we will restrict ourself to the http scheme
+
+```
+http
+```{{exec}}
+
 As said in the previous chapter, we will use the nginx ingress in this demo deployment
 
 ```
 nginx
-```{{exec}}
-
-for the demo deployment we are not generating certificates, so we will restrict ourself to the http scheme
-
-```
-http
 ```{{exec}}
 
 as a domain, we use eoepca.local, which is mapped to the local machine in this demo

--- a/processing/calrissian/configurezoo2.md
+++ b/processing/calrissian/configurezoo2.md
@@ -1,4 +1,4 @@
-we are configuration the Calrissian Kubernetes processing engine, so we need to select it
+we are configuring the Calrissian Kubernetes processing engine, so we need to select it
 
 ```
 calrissian

--- a/processing/calrissian/deployapp.md
+++ b/processing/calrissian/deployapp.md
@@ -1,6 +1,6 @@
 we have now a [OGC Process API](https://ogcapi.ogc.org/processes/) compliant interface offered by zoo, which we can use to deploy and run applications within our platform.
 
-Applications in Zoo are deployed according to the [OGC Best Practices for Earth Observation Application Pakcage](https://docs.ogc.org/bp/20-089r1.html). These specify applications packaged in a [Docker](https://www.docker.com/) container, with input, output and processing steps defined in a [CWL file](https://www.commonwl.org/).
+Applications in Zoo are deployed according to the [OGC Best Practices for Earth Observation Application Package](https://docs.ogc.org/bp/20-089r1.html). These specify applications packaged in a [Docker](https://www.docker.com/) container, with input, output and processing steps defined in a [CWL file](https://www.commonwl.org/).
 
 You can see what a sample CWL application looks like from the deployment guide examples, via
 

--- a/processing/calrissian/deployapp2.md
+++ b/processing/calrissian/deployapp2.md
@@ -8,7 +8,7 @@ If we have a look at the `test`{{}} user namespace, as in the command below, we 
 curl -s -S http://zoo.eoepca.local/test/ogc-api/processes/  | jq -r .processes[].id
 ```{{exec}}
 
-To deploy the application, we can do a POST to the the processes endpoint, including the CWL representing the [OGC Application Pakcage](https://docs.ogc.org/bp/20-089r1.html):
+To deploy the application, we can do a POST to the the processes endpoint, including the CWL representing the [OGC Application Package](https://docs.ogc.org/bp/20-089r1.html):
 
 ```
 curl -s -S -X POST -H "Content-Type: application/cwl+yaml" -H "Accept: application/json" -d "$(cat ~/deployment-guide/scripts/processing/oapip/examples/convert-url-app.cwl)" http://zoo.eoepca.local/test/ogc-api/processes/  | jq

--- a/processing/calrissian/finish.md
+++ b/processing/calrissian/finish.md
@@ -8,7 +8,7 @@ For more information about EOEPCA and the EOEPCA Processing Building Block, and 
  - [EOEPCA Deployment Guide](https://eoepca.readthedocs.io/projects/deploy/en/latest/)
  - [General EOEPCA Documentation](https://eoepca.readthedocs.io/)
  - [OGC Process API](https://ogcapi.ogc.org/processes/)
- - [OGC Best Practices for Earth Observation Application Pakcage](https://docs.ogc.org/bp/20-089r1.html)
+ - [OGC Best Practices for Earth Observation Application Package](https://docs.ogc.org/bp/20-089r1.html)
  - [Zoo Project Documentation](https://zoo-project.org/resources/userguide/)
  - [Calrissian Documentation](https://duke-gcb.github.io/calrissian/)
 

--- a/processing/calrissian/intro.md
+++ b/processing/calrissian/intro.md
@@ -2,10 +2,10 @@ Welcome to the EOEPCA Processing Building Block, [OGC Process API](https://ogcap
 
 EOEPCA provides different data processing solutions tailored to different use cases. In general, bulk data processing and systematic processing operations are performed using the [OGC Process API](https://ogcapi.ogc.org/processes/) interface, while interactive data processing tasks and data analytics is performed via the [OpenEO API](https://api.openeo.org/) interface.
 
-This is anyway not a given, and a lot will depend on the different use-cases and preferences of the user communities. EOEPCA allows in any case to deploy, at the same time and sharing the same infrastructure resources, both [OGC Process API](https://ogcapi.ogc.org/processes/) and [OpenEO API](https://api.openeo.org/) interafaces.
+This is anyway not a given, and a lot will depend on the different use-cases and preferences of the user communities. EOEPCA allows in any case to deploy, at the same time and sharing the same infrastructure resources, both [OGC Process API](https://ogcapi.ogc.org/processes/) and [OpenEO API](https://api.openeo.org/) interfaces.
 
 For the OGC Process API interface, different "execution engines" are available, allowing to submit data processing jobs to different backends. At the time, [Argo workflows](./argo), K8S jobs (via Calrissian) or HPC jobs (via [Toil](./toil)) are supported.
 
-This tutorial will focus on deploying an [OGC Process API](https://ogcapi.ogc.org/processes/) interface, via the [Zoo software](https://zoo-project.org/), submitting data processing jobs to the a Kubernetes cluster via [Calrissian](https://github.com/Duke-GCB/calrissian) cookiecutter Zoo template.
+This tutorial will focus on deploying an [OGC Process API](https://ogcapi.ogc.org/processes/) interface, via the [Zoo software](https://zoo-project.org/), submitting data processing jobs to a Kubernetes cluster via [Calrissian](https://github.com/Duke-GCB/calrissian) cookiecutter Zoo template.
 
 Note that this tutorial assumes a generic knowledge of EOEPCA and its pre-requisites. If you did not already, it is then strongly suggested to follow the [EOEPCA introduction tutorials](../intro) before continuing with this tutorial.

--- a/processing/calrissian/monitorproc.md
+++ b/processing/calrissian/monitorproc.md
@@ -1,4 +1,4 @@
-Now the application is running. We can see, after few seconds, that a new namespace starting with `convert-url`{{}} is created,
+Now the application is running. We can see, after a few seconds, that a new namespace starting with `convert-url`{{}} is created,
 
 ```
 kubectl get namespaces

--- a/processing/calrissian/prerequisite_k8s.md
+++ b/processing/calrissian/prerequisite_k8s.md
@@ -8,7 +8,7 @@ To check the Kubernetes cluster is properly installed, run
 kubectl get -n ingress-nginx pods
 ```{{exec}}
 
-, which should return an `ingress-nginx-controller`{{}} pod, and try to access the storage and data processing endpoints with
+which should return an `ingress-nginx-controller`{{}} pod, and try to access the storage and data processing endpoints with
 
 ```
 curl -s -S http://zoo.eoepca.local

--- a/processing/calrissian/submitproc.md
+++ b/processing/calrissian/submitproc.md
@@ -4,7 +4,7 @@ Once the processing request is submitted, Zoo will invoke Calrissian, which will
 
 The jobs will gather the input, execute the processing and in the push the output inside the platform object storage.
 
-From the [OGC Process API](https://ogcapi.ogc.org/processes/) interface we will be able to monitor the status of the job and, at the end of its successful completition, retreive its output.
+From the [OGC Process API](https://ogcapi.ogc.org/processes/) interface we will be able to monitor the status of the job and, at the end of its successful completition, retrieve its output.
 
 So, let's start to submit a processing request to the convert-url application.
 

--- a/processing/toil/finish.md
+++ b/processing/toil/finish.md
@@ -8,7 +8,7 @@ For more information about EOEPCA and the EOEPCA Processing Building Block, and 
  - [EOEPCA Deployment Guide](https://eoepca.readthedocs.io/projects/deploy/en/latest/)
  - [General EOEPCA Documentation](https://eoepca.readthedocs.io/)
  - [OGC Process API](https://ogcapi.ogc.org/processes/)
- - [OGC Best Practices for Earth Observation Application Pakcage](https://docs.ogc.org/bp/20-089r1.html)
+ - [OGC Best Practices for Earth Observation Application Package](https://docs.ogc.org/bp/20-089r1.html)
  - [Zoo Project Documentation](https://zoo-project.org/resources/userguide/)
  - [Toil WES Runner Documentation](https://zoo-project.github.io/zoo-wes-runner/)
  - [Toil Documentation](https://toil.ucsc-cgl.org/)

--- a/processing/toil/install_toil2.md
+++ b/processing/toil/install_toil2.md
@@ -1,4 +1,4 @@
-to test Toil is correctly installed, we will use a [OGC Best Practices for Earth Observation Application Pakcage](https://docs.ogc.org/bp/20-089r1.html) applications, which are the ones the EOEPCA Building Block [OGC Process API](https://ogcapi.ogc.org/processes/) interface supports for execution.
+to test Toil is correctly installed, we will use a [OGC Best Practices for Earth Observation Application Package](https://docs.ogc.org/bp/20-089r1.html) applications, which are the ones the EOEPCA Building Block [OGC Process API](https://ogcapi.ogc.org/processes/) interface supports for execution.
 
 We will go in more details about such applications later in the tutorial, in the mean time, we will just test now that Toil works correctly by running one of these example applications
 

--- a/processing/toil/intro.md
+++ b/processing/toil/intro.md
@@ -8,4 +8,4 @@ For the OGC Process API interface, different "execution engines" are available, 
 
 This tutorial will focus on deploying an [OGC Process API](https://ogcapi.ogc.org/processes/) interface, via the [Zoo software](https://zoo-project.org/), submitting data processing jobs to a Toil Workflow Execution Service HPC cluster via [Toil](https://toil.readthedocs.io/en/master/running/server/wes.html) cookiecutter Zoo template.
 
-Note that this tutorial assumes a generic knowledge of EOEPCA and its pre-requisites. If you did not already, it is then strongly suggested to follow the [EOEPCA introduction tutorials](../intro) before continuing with this tutorial.
+Note that this tutorial assumes a generic knowledge of EOEPCA and its pre-requisites. If you did not already, it is then strongly suggested to follow the <a href="../intro" target="_blank" rel="noopener noreferrer">EOEPCA introduction tutorials</a> before continuing with this tutorial.

--- a/processing/toil/intro.md
+++ b/processing/toil/intro.md
@@ -2,7 +2,7 @@ Welcome to the EOEPCA Processing Building Block, [OGC Process API](https://ogcap
 
 EOEPCA provides different data processing solutions tailored to different use cases. In general, bulk data processing and systematic processing operations are performed using the [OGC Process API](https://ogcapi.ogc.org/processes/) interface, while interactive data processing tasks and data analytics is performed via the [OpenEO API](https://api.openeo.org/) interface.
 
-This is anyway not a given, and a lot will depend on the different use-cases and preferences of the user communities. EOEPCA allows in any case to deploy, at the same time and sharing the same infrastructure resources, both [OGC Process API](https://ogcapi.ogc.org/processes/) and [OpenEO API](https://api.openeo.org/) interafaces.
+This is anyway not a given, and a lot will depend on the different use-cases and preferences of the user communities. EOEPCA allows in any case to deploy, at the same time and sharing the same infrastructure resources, both [OGC Process API](https://ogcapi.ogc.org/processes/) and [OpenEO API](https://api.openeo.org/) interfaces.
 
 For the OGC Process API interface, different "execution engines" are available, allowing to submit data processing jobs to different backends. At the time, [Argo workflows](./argo), K8S jobs (via Calrissian) or HPC jobs (via [Toil](./toil)) are supported.
 

--- a/processing/toil/monitorproc.md
+++ b/processing/toil/monitorproc.md
@@ -1,4 +1,4 @@
-Now the application is running. We can see, after few seconds, that a new Toil WES request has been performed and is in processing:
+Now the application is running. We can see, after a few seconds, that a new Toil WES request has been performed and is in processing:
 
 ```
 tail -n 10 ~ubuntu/celery.log

--- a/processing/toil/prerequisite_condor.md
+++ b/processing/toil/prerequisite_condor.md
@@ -21,4 +21,4 @@ and test that our HTCondor is properly accessible via:
 condor_status
 ```{{exec}}
 
-we will then, in the next steps, procede to the installation of the Toil software and Toil WES interface on own HPC cluster
+we will then, in the next steps, proceed to the installation of the Toil software and Toil WES interface on own HPC cluster

--- a/processing/toil/submitproc.md
+++ b/processing/toil/submitproc.md
@@ -4,7 +4,7 @@ Once the processing request is submitted, Zoo will invoke Calrissian, which will
 
 The jobs will gather the input, execute the processing and in the push the output inside the platform object storage.
 
-From the [OGC Process API](https://ogcapi.ogc.org/processes/) interface we will be able to monitor the status of the job and, at the end of its successful completition, retreive its output.
+From the [OGC Process API](https://ogcapi.ogc.org/processes/) interface we will be able to monitor the status of the job and, at the end of its successful completition, retrieve its output.
 
 So, let's start to submit a processing request to the convert-url application.
 


### PR DESCRIPTION
Mostly wording/typos.

NOTE that some updates reflect use of the current `main` branch (soon to be tagged `eoepca-2.0-rc1b`) of the Deployment Guide - e.g. ordering of questions, which changed for a good reason.

@spinto Looks like this PR somehow includes the IAM commits that are already present in #4 - hopefully this will not confuse the merging. In fact maybe the PR #4 is not required.