### PR TITLE
/usr/bin/python doesn't exist in the image but /usr/bin/python3 does.

### DIFF
--- a/commons/intro_background.sh
+++ b/commons/intro_background.sh
@@ -351,7 +351,7 @@ if [[ -e /tmp/assets/htcondor ]]; then
   #Allow ubuntu user to submit jobs
   usermod -a -G docker ubuntu
   #Mount the local /etc/hosts in docker for the DNS resolution
-  echo '#!/usr/bin/python
+  echo '#!/usr/bin/python3
 import sys, os
 n=sys.argv
 n[0]="/usr/bin/docker"


### PR DESCRIPTION
/usr/local/bin/docker broke because it uses `#!/usr/bin/python`, which doesn't exist in either Localcoda image (it _does_ exist in Killercoda). /usr/bin/python3 exists in all of them.