### PR TITLE
Realign config script answers

### DIFF
--- a/discovery/01-prerequisites.md
+++ b/discovery/01-prerequisites.md
@@ -21,20 +21,15 @@ bash check-prerequisites.sh
 
 This will ask a few questions about the Kubernetes cluster configuration and check if all the necessary pre-requirements are installed. 
 
-EOEPCA components can work with or without certificates. We choose the `http` scheme since we are not using certificates and encryption for our tutorial:
-```
-http
-```{{exec}}
-
 EOEPCA components can work with different Ingress services installed in your Kubernetes cluster. The default configuration uses [apisix](https://apisix.apache.org/) to provide advanced authentication and authorization. For this demo environment, we will use the simpler nginx ingress without authorization
 
 ```
 nginx
 ```{{exec}}
 
-We enter the top-level domain for our EOEPCA services:
+We accept the pre-configured top-level domain for our EOEPCA services:
 ```
-eoepca.local
+n
 ```{{exec}}
 
 We do not need a specific Storage Class for this component, so for this example we will use the basic storage class provided in this sandbox. Note that, in an operational environment, you should use a reliable (and possibly redundant and backed up) storage class, as this storage class will be used to store all the metadata of your data

--- a/discovery/04-add-stac.md
+++ b/discovery/04-add-stac.md
@@ -38,7 +38,7 @@ curl --silent http://resource-catalogue.eoepca.local/stac/collections | jq .coll
 
 or via the [STAC browser](https://radiantearth.github.io/stac-browser/#/external/{{TRAFFIC_HOST1_81}}/stac) or via the [internal GUI]({{TRAFFIC_HOST1_81}}/collections/metadata:main/items)
 
-> NOTE that the STAC Browser will not work in the case that (insecure) `http` has been used to expose the Resource Catalogue service, though it may work in some browsers (like Firefox) if you allow mixed http/https content for the site in your browser
+> NOTE that the STAC Browser will not work in Localcoda because it exposes proxied ports with plain HTTP, though it may work in some browsers (like Firefox) if you allow mixed http/https content for the site in your browser
 
 ### Add an Item
 
@@ -87,4 +87,4 @@ curl --silent http://resource-catalogue.eoepca.local/stac/collections/CAT_DEMO/i
 
 And in the [STAC browser](https://radiantearth.github.io/stac-browser/#/external/{{TRAFFIC_HOST1_81}}/stac) or via the [internal GUI]({{TRAFFIC_HOST1_81}}/collections/CAT_DEMO/items)
 
-> NOTE that the STAC Browser will not work in the case that (insecure) `http` has been used to expose the Resource Catalogue service, though it may work in some browsers (like Firefox) if you allow mixed http/https content for the site in your browser
+> NOTE that the STAC Browser will not work in Localcoda because it exposes proxied ports with plain HTTP, though it may work in some browsers (like Firefox) if you allow mixed http/https content for the site in your browser

--- a/discovery/04-add-stac.md
+++ b/discovery/04-add-stac.md
@@ -38,7 +38,7 @@ curl --silent http://resource-catalogue.eoepca.local/stac/collections | jq .coll
 
 or via the [STAC browser](https://radiantearth.github.io/stac-browser/#/external/{{TRAFFIC_HOST1_81}}/stac) or via the [internal GUI]({{TRAFFIC_HOST1_81}}/collections/metadata:main/items)
 
-> NOTE that the STAC Browser will not work in the case that (insecure) `http` has been used to expose the Resource Catalogue service.
+> NOTE that the STAC Browser will not work in the case that (insecure) `http` has been used to expose the Resource Catalogue service, though it may work in some browsers (like Firefox) if you allow mixed http/https content for the site in your browser
 
 ### Add an Item
 
@@ -87,4 +87,4 @@ curl --silent http://resource-catalogue.eoepca.local/stac/collections/CAT_DEMO/i
 
 And in the [STAC browser](https://radiantearth.github.io/stac-browser/#/external/{{TRAFFIC_HOST1_81}}/stac) or via the [internal GUI]({{TRAFFIC_HOST1_81}}/collections/CAT_DEMO/items)
 
-> NOTE that the STAC Browser will not work in the case that (insecure) `http` has been used to expose the Resource Catalogue service.
+> NOTE that the STAC Browser will not work in the case that (insecure) `http` has been used to expose the Resource Catalogue service, though it may work in some browsers (like Firefox) if you allow mixed http/https content for the site in your browser


### PR DESCRIPTION
The configuration script's questions changed due to the pre-setting of HTTP_SCHEME and INGRESS_HOST in https://github.com/EOEPCA/eoepca-killercoda/commit/dfa8c2bd352f1cc6e85160678b5569eddb6a2815#diff-835d11dd4f1cdbfe01673d784d96956b1319d1940953f4b3f5573a7edebc2a2e.

This realigns them.

Also, add a note that, in some browsers, stac browser can be made to work by allowing mixed content. Doesn't work in Chrome because of a CORS complaint but works in Firefox.