### PR TITLE
Align apisix install commands and check text

### DIFF
--- a/prerequisites/01b-checks.md
+++ b/prerequisites/01b-checks.md
@@ -56,6 +56,10 @@ And we are faced with some questions about the configuration we are going to use
   no
   no
   ```{{exec}}
+- Kubernetes storage class for shared volumes
+  ```
+  standard
+  ```{{exec}}
 
 --- 
 

--- a/prerequisites/04-ingress.md
+++ b/prerequisites/04-ingress.md
@@ -82,15 +82,18 @@ helm repo add apisix https://charts.apiseven.com
 helm repo update apisix
 
 helm upgrade -i apisix apisix/apisix \
-  --version 2.9.0 \
+  --version 2.10.0 \
   --namespace ingress-apisix --create-namespace \
   --set securityContext.runAsUser=0 \
   --set hostNetwork=true \
   --set service.http.containerPort=80 \
   --set apisix.ssl.containerPort=443 \
+  --set etcd.image.repository=bitnamilegacy/etcd \
   --set etcd.replicaCount=1 \
+  --set etcd.persistence.storageClass="local-path" \
   --set apisix.enableIPv6=false \
   --set apisix.enableServerTokens=false \
+  --set apisix.ssl.enabled=true \
   --set ingress-controller.enabled=true
 ```{{exec}}
 

--- a/prerequisites/04-ingress.md
+++ b/prerequisites/04-ingress.md
@@ -4,7 +4,7 @@ Most ingresses work in conjunction Load Balancer, this because the Kubernetes cl
 
 Back to the Ingress, EOEPCA can be deployed with two types of Ingress controllers, the [nginx ingress controller](https://docs.nginx.com/nginx-ingress-controller/) and the [APISIX](https://apisix.apache.org/) ingress controller.
 
-Note that most kubernetes clusters from cloud providers or from local installations (like [Rancher](https://www.rancher.com/)] will provide you already with an nginx ingree controller, while you will need to install APISIX, if required, manually.
+Note that most kubernetes clusters from cloud providers or from local installations (like [Rancher](https://www.rancher.com/)) will provide you already with an nginx ingree controller, while you will need to install APISIX, if required, manually.
 
 For EOEPCA, the nginx controller can be used for most building blocks without authorization, while authorization is provided via APISIX. For details refer to the [relevant section of the EOEPCA Deployment Guide](https://eoepca.readthedocs.io/projects/deploy/en/latest/prerequisites/ingress/overview/)
 
@@ -61,7 +61,7 @@ spec:
 EOF
 ```{{exec}}
 
-Now we can check if our ingress works. We need first to wait some time for the ingress to be cnfigured properly, then we can attempt to connect one of the services we have configured in DNS:
+Now we can check if our ingress works. We need first to wait some time for the ingress to be configured properly, then we can attempt to connect one of the services we have configured in DNS:
 ```
 sleep 5
 curl -s -S http://test.eoepca.local
@@ -75,7 +75,7 @@ If instead of using nginx we want to use APISIX, which is the one required to en
 helm uninstall -n ingress-nginx ingress-nginx
 ```{{exec}}
 
-Then, to install APISIX in our sangbox, the installation can be performed with the following commands in our sandbox environent.
+Then, to install APISIX in our sandbox, the installation can be performed with the following commands in our sandbox environent.
 
 ```
 helm repo add apisix https://charts.apiseven.com

--- a/prerequisites/06-prerequisites-2.md
+++ b/prerequisites/06-prerequisites-2.md
@@ -1,7 +1,8 @@
-Now we re-check whether all the prerequisites are met. To do this, we run the `check-prerequisites` script again, answering `no` to the two questions:
+Now we re-check whether all the prerequisites are met. To do this, we run the `check-prerequisites` script again, answering `no` to the three questions:
 ```
 cd ~/deployment-guide/scripts/infra-prereq
 bash check-prerequisites.sh
+no
 no
 no
 ```{{exec}}

--- a/prerequisites/99-finish.md
+++ b/prerequisites/99-finish.md
@@ -4,7 +4,7 @@ You can now play more with the deployed software, or jump to another one of the 
 
 For more information about EOEPCA and the EOEPCA Processing Building Block, and more advance deployments, have a look at the:
  - [EOEPCA Website](https://eoepca.org/)
- - [EOEPCA Git PRepository](https://github.com/EOEPCA/)
+ - [EOEPCA Git Repository](https://github.com/EOEPCA/)
  - [EOEPCA Deployment Guide](https://eoepca.readthedocs.io/projects/deploy/en/latest/)
  - [General EOEPCA Documentation](https://eoepca.readthedocs.io/)
  - [Pre-requisites in EOEPCA Documentaiton](https://eoepca.readthedocs.io/projects/deploy/en/latest/prerequisites/prerequisites-overview/)


### PR DESCRIPTION
The APISIX Helm installation settings in the pre-requisites tutorial didn't match those used to install it automatically in other tutorials nor the one in the deployment guide. This updates the pre-requisites tutorial to match as closely as possible. This includes the bitnami/bitnamilegacy change  necessary to keep it working.

There are also some tweaks to the text for spelling, etc.