### PR TITLE
fix: tutorial fails to complete

### DIFF
--- a/prerequisites/05-cert-manager.md
+++ b/prerequisites/05-cert-manager.md
@@ -23,6 +23,7 @@ popd
 
 We can check if our ClusterIssuer is present:
 ```
+sleep 5
 kubectl --namespace cert-manager get clusterissuer -o wide
 ```{{exec}}
 

--- a/prerequisites/07-minio.md
+++ b/prerequisites/07-minio.md
@@ -41,6 +41,12 @@ helm upgrade -i minio minio/minio \
   --create-namespace
 ```{{exec}}
 
+Apply additional ingress configuration:
+
+```bash
+kubectl -n minio apply -f ingress-plugin-config.yaml
+```{{exec}}
+
 We wait until the all pods in the `minio`{{}} namespace are ready:
 ```
 kubectl --namespace minio wait pod --all --timeout=10m --for=condition=Ready
@@ -73,6 +79,7 @@ mc alias set minio-local http://minio.eoepca.local/ ${MINIO_USER} ${MINIO_PASSWO
 
 Create Access Key:
 ```
+sleep 5
 mc admin accesskey create minio-local/ user --access-key ${S3_ACCESS_KEY} --secret-key ${S3_SECRET_KEY}
 ```{{exec}}
 


### PR DESCRIPTION
The tutorial "Prerequisites" breaks at the section "S3 Object Storage", because MinIO can't be reached due to routing failure.

This change enables Ingress to work properly, by providing the necessary requirements.